### PR TITLE
Add SQL modes to database config for MySQL v8

### DIFF
--- a/config/database.php
+++ b/config/database.php
@@ -52,6 +52,14 @@ return [
             'prefix' => '',
             'strict' => true,
             'engine' => null,
+            'modes'  => [
+                'ONLY_FULL_GROUP_BY',
+                'STRICT_TRANS_TABLES',
+                'NO_ZERO_IN_DATE',
+                'NO_ZERO_DATE',
+                'ERROR_FOR_DIVISION_BY_ZERO',
+                'NO_ENGINE_SUBSTITUTION',
+            ],            
         ],
 
         'pgsql' => [


### PR DESCRIPTION
This PR fixes the following error on MySQL v8

```
Syntax error or access violation: 1231 Variable 'sql_mode' can't be set to the value of 'NO_AUTO_CREATE_USER'
```
