### PR TITLE
Admin for Managing All Users and DB Backup Manager

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -3,6 +3,7 @@ APP_KEY=
 APP_DEBUG=true
 APP_LOG_LEVEL=debug
 APP_URL=http://localhost
+SYSTEM_ADMIN_EMAILS=
 
 LOG_CHANNEL=stack
 

--- a/app/Helpers/functions.php
+++ b/app/Helpers/functions.php
@@ -58,3 +58,15 @@ function userPhotoPath($photoPath, $genderId)
 
     return asset('images/icon_user_'.$genderId.'.png');
 }
+
+function is_system_admin(User $user)
+{
+    if ($user->email) {
+        if (env('SYSTEM_ADMIN_EMAILS')) {
+            $adminEmails = explode(';', env('SYSTEM_ADMIN_EMAILS'));
+            return in_array($user->email, $adminEmails);
+        }
+    }
+
+    return false;
+}

--- a/app/Helpers/functions.php
+++ b/app/Helpers/functions.php
@@ -62,8 +62,8 @@ function userPhotoPath($photoPath, $genderId)
 function is_system_admin(User $user)
 {
     if ($user->email) {
-        if (env('SYSTEM_ADMIN_EMAILS')) {
-            $adminEmails = explode(';', env('SYSTEM_ADMIN_EMAILS'));
+        if (config('app.system_admin_emails')) {
+            $adminEmails = explode(';', config('app.system_admin_emails'));
             return in_array($user->email, $adminEmails);
         }
     }

--- a/app/Http/Kernel.php
+++ b/app/Http/Kernel.php
@@ -53,6 +53,7 @@ class Kernel extends HttpKernel
     protected $routeMiddleware = [
         'auth' => \Illuminate\Auth\Middleware\Authenticate::class,
         'auth.basic' => \Illuminate\Auth\Middleware\AuthenticateWithBasicAuth::class,
+        'admin' => \App\Http\Middleware\AdminOnly::class,
         'bindings' => \Illuminate\Routing\Middleware\SubstituteBindings::class,
         'can' => \Illuminate\Auth\Middleware\Authorize::class,
         'guest' => \App\Http\Middleware\RedirectIfAuthenticated::class,

--- a/app/Http/Middleware/AdminOnly.php
+++ b/app/Http/Middleware/AdminOnly.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace App\Http\Middleware;
+
+use Closure;
+
+class AdminOnly
+{
+    /**
+     * Handle an incoming request.
+     *
+     * @param  \Illuminate\Http\Request  $request
+     * @param  \Closure  $next
+     * @return mixed
+     */
+    public function handle($request, Closure $next)
+    {
+        if (!is_system_admin($request->user())) {
+            abort(403);
+        }
+
+        return $next($request);
+    }
+}

--- a/app/Policies/CouplePolicy.php
+++ b/app/Policies/CouplePolicy.php
@@ -19,6 +19,6 @@ class CouplePolicy
      */
     public function edit(User $user, Couple $couple)
     {
-        return $couple->manager_id == $user->id;
+        return $couple->manager_id == $user->id || is_system_admin($user);
     }
 }

--- a/app/Policies/UserPolicy.php
+++ b/app/Policies/UserPolicy.php
@@ -30,6 +30,6 @@ class UserPolicy
      */
     public function delete(User $user, User $editableUser)
     {
-        return $editableUser->manager_id == $user->id && $editableUser->id != $user->id;
+        return ($editableUser->manager_id == $user->id || is_system_admin($user)) && $editableUser->id != $user->id;
     }
 }

--- a/app/Policies/UserPolicy.php
+++ b/app/Policies/UserPolicy.php
@@ -18,7 +18,7 @@ class UserPolicy
      */
     public function edit(User $user, User $editableUser)
     {
-        return $editableUser->id == $user->id || $editableUser->manager_id == $user->id;
+        return $editableUser->id == $user->id || $editableUser->manager_id == $user->id || is_system_admin($user);
     }
 
     /**

--- a/config/app.php
+++ b/config/app.php
@@ -29,6 +29,18 @@ return [
 
     /*
     |--------------------------------------------------------------------------
+    | System Administrator Emails
+    |--------------------------------------------------------------------------
+    |
+    | This is config stores emails of users who have role of administrators.
+    | The user can edit and delete any users and marriages int he system.
+    |
+    */
+
+    'system_admin_emails' => env('SYSTEM_ADMIN_EMAILS'),
+
+    /*
+    |--------------------------------------------------------------------------
     | Application Debug Mode
     |--------------------------------------------------------------------------
     |

--- a/resources/lang/en/birthday.php
+++ b/resources/lang/en/birthday.php
@@ -1,9 +1,10 @@
 <?php
 
 return [
-    'birthday'  => 'Birhtday',
-    'upcoming'  => 'Upcoming birthdays',
-    'remaining' => ':count days',
-    'age_years' => ':age years',
-    'days'      => 'days',
+    'birthday'    => 'Birthday',
+    'upcoming'    => 'Upcoming birthdays',
+    'no_upcoming' => 'No upcoming birthdays in the next :days days.',
+    'remaining'   => ':count days',
+    'age_years'   => ':age years',
+    'days'        => 'days',
 ];

--- a/resources/lang/id/birthday.php
+++ b/resources/lang/id/birthday.php
@@ -1,9 +1,10 @@
 <?php
 
 return [
-    'birthday'  => 'Ulang Tahun',
-    'upcoming'  => 'Ulang tahun akan datang',
-    'remaining' => ':count hari',
-    'age_years' => ':age tahun',
-    'days'      => 'Hari',
+    'birthday'    => 'Ulang Tahun',
+    'upcoming'    => 'Ulang tahun akan datang',
+    'no_upcoming' => 'Belum ada ulang tahun dalam :days hari kedepan.',
+    'remaining'   => ':count hari',
+    'age_years'   => ':age tahun',
+    'days'        => 'Hari',
 ];

--- a/resources/views/birthdays/index.blade.php
+++ b/resources/views/birthdays/index.blade.php
@@ -35,7 +35,7 @@
                     </tr>
                     @empty
                     <tr>
-                        <td colspan="4">{{ __('user.no_upcoming_birthday', ['days' => 60]) }}</td>
+                        <td colspan="4">{{ __('birthday.no_upcoming', ['days' => 60]) }}</td>
                     </tr>
                     @endforelse
                 </tbody>

--- a/resources/views/layouts/partials/nav.blade.php
+++ b/resources/views/layouts/partials/nav.blade.php
@@ -39,7 +39,9 @@
                         </a>
 
                         <ul class="dropdown-menu" role="menu">
-                            <li><a href="{{ route('backups.index') }}">{{ __('backup.list') }}</a></li>
+                            @if (is_system_admin(auth()->user()))
+                                <li><a href="{{ route('backups.index') }}">{{ __('backup.list') }}</a></li>
+                            @endif
                             <li><a href="{{ route('profile') }}">{{ __('app.my_profile') }}</a></li>
                             <li><a href="{{ route('password.change') }}">{{ __('auth.change_password') }}</a></li>
                             <li>

--- a/routes/web.php
+++ b/routes/web.php
@@ -50,9 +50,14 @@ Route::get('couples/{couple}/edit', ['as' => 'couples.edit', 'uses' => 'CouplesC
 Route::patch('couples/{couple}', ['as' => 'couples.update', 'uses' => 'CouplesController@update']);
 
 /**
- * Backup Restore Database Routes
+ * Admin only routes
  */
-Route::post('backups/upload', ['as' => 'backups.upload', 'uses' => 'BackupsController@upload']);
-Route::post('backups/{fileName}/restore', ['as' => 'backups.restore', 'uses' => 'BackupsController@restore']);
-Route::get('backups/{fileName}/dl', ['as' => 'backups.download', 'uses' => 'BackupsController@download']);
-Route::resource('backups', 'BackupsController');
+Route::group(['middleware' => 'admin'], function () {
+    /**
+     * Backup Restore Database Routes
+     */
+    Route::post('backups/upload', ['as' => 'backups.upload', 'uses' => 'BackupsController@upload']);
+    Route::post('backups/{fileName}/restore', ['as' => 'backups.restore', 'uses' => 'BackupsController@restore']);
+    Route::get('backups/{fileName}/dl', ['as' => 'backups.download', 'uses' => 'BackupsController@download']);
+    Route::resource('backups', 'BackupsController');
+});

--- a/tests/Unit/Helpers/IsSystemAdminHelperTest.php
+++ b/tests/Unit/Helpers/IsSystemAdminHelperTest.php
@@ -12,7 +12,7 @@ class IsSystemAdminHelperTest extends TestCase
     {
         $adminEmail1 = 'admin1@example.net';
         $adminEmail2 = 'admin2@example.net';
-        putenv('SYSTEM_ADMIN_EMAILS='.$adminEmail1.';'.$adminEmail2);
+        config(['app.system_admin_emails' => $adminEmail1.';'.$adminEmail2]);
 
         $admin1 = factory(User::class)->make(['email' => $adminEmail1]);
         $admin2 = factory(User::class)->make(['email' => $adminEmail2]);
@@ -21,6 +21,23 @@ class IsSystemAdminHelperTest extends TestCase
 
         $this->assertTrue(is_system_admin($admin1));
         $this->assertTrue(is_system_admin($admin2));
+        $this->assertFalse(is_system_admin($userWithEmail));
+        $this->assertFalse(is_system_admin($userWithNoEmail));
+    }
+
+    /** @test */
+    public function if_config_is_null()
+    {
+        $adminEmail1 = 'admin1@example.net';
+        $adminEmail2 = 'admin2@example.net';
+
+        $admin1 = factory(User::class)->make(['email' => $adminEmail1]);
+        $admin2 = factory(User::class)->make(['email' => $adminEmail2]);
+        $userWithEmail = factory(User::class)->make(['email' => 'user@example.net']);
+        $userWithNoEmail = factory(User::class)->make(['email' => null]);
+
+        $this->assertFalse(is_system_admin($admin1));
+        $this->assertFalse(is_system_admin($admin2));
         $this->assertFalse(is_system_admin($userWithEmail));
         $this->assertFalse(is_system_admin($userWithNoEmail));
     }

--- a/tests/Unit/Helpers/IsSystemAdminHelperTest.php
+++ b/tests/Unit/Helpers/IsSystemAdminHelperTest.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace Tests\Unit\Helpers;
+
+use App\User;
+use Tests\TestCase;
+
+class IsSystemAdminHelperTest extends TestCase
+{
+    /** @test */
+    public function user_is_an_admin()
+    {
+        $adminEmail1 = 'admin1@example.net';
+        $adminEmail2 = 'admin2@example.net';
+        putenv('SYSTEM_ADMIN_EMAILS='.$adminEmail1.';'.$adminEmail2);
+
+        $admin1 = factory(User::class)->make(['email' => $adminEmail1]);
+        $admin2 = factory(User::class)->make(['email' => $adminEmail2]);
+        $userWithEmail = factory(User::class)->make(['email' => 'user@example.net']);
+        $userWithNoEmail = factory(User::class)->make(['email' => null]);
+
+        $this->assertTrue(is_system_admin($admin1));
+        $this->assertTrue(is_system_admin($admin2));
+        $this->assertFalse(is_system_admin($userWithEmail));
+        $this->assertFalse(is_system_admin($userWithNoEmail));
+    }
+}

--- a/tests/Unit/Policies/CouplePolicyTest.php
+++ b/tests/Unit/Policies/CouplePolicyTest.php
@@ -3,7 +3,9 @@
 namespace Tests\Unit\Policies;
 
 use App\Couple;
+use App\User;
 use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Str;
 use Tests\TestCase;
 
 class CouplePolicyTest extends TestCase
@@ -11,11 +13,33 @@ class CouplePolicyTest extends TestCase
     use RefreshDatabase;
 
     /** @test */
-    public function admin_can_edit_couple_data()
+    public function manager_can_edit_couples()
     {
-        $couple = factory(Couple::class)->create();
-        $manager = $couple->manager;
+        $otherCoupleManagerId = Str::random();
+        $manager = factory(User::class)->create();
+        $couple = factory(Couple::class)->create(['manager_id' => $manager->id]);
+        $otherCouple = factory(Couple::class)->create(['manager_id' => $otherCoupleManagerId]);
 
         $this->assertTrue($manager->can('edit', $couple));
+        $this->assertFalse($manager->can('edit', $otherCouple));
+    }
+
+    /** @test */
+    public function admins_can_edit_any_couple_data()
+    {
+        $adminEmail = 'admin@example.net';
+        $otherCoupleManagerId = Str::random();
+        config(['app.system_admin_emails' => $adminEmail]);
+
+        $manager = factory(User::class)->create();
+        $admin = factory(User::class)->create(['email' => $adminEmail]);
+        $couple = factory(Couple::class)->create(['manager_id' => $manager->id]);
+        $otherCouple = factory(Couple::class)->create(['manager_id' => $otherCoupleManagerId]);
+
+        $this->assertTrue($admin->can('edit', $couple));
+        $this->assertTrue($admin->can('edit', $otherCouple));
+
+        $this->assertTrue($manager->can('edit', $couple));
+        $this->assertFalse($manager->can('edit', $otherCouple));
     }
 }

--- a/tests/Unit/Policies/UserPolicyTest.php
+++ b/tests/Unit/Policies/UserPolicyTest.php
@@ -28,7 +28,7 @@ class UserPolicyTest extends TestCase
     {
         $adminEmail = 'admin@example.net';
         $otherUserManagerId = Str::random();
-        putenv('SYSTEM_ADMIN_EMAILS='.$adminEmail);
+        config(['app.system_admin_emails' => $adminEmail]);
 
         $manager = factory(User::class)->create();
         $admin = factory(User::class)->create(['email' => $adminEmail]);
@@ -67,7 +67,7 @@ class UserPolicyTest extends TestCase
     {
         $adminEmail = 'admin@example.net';
         $otherUserManagerId = Str::random();
-        putenv('SYSTEM_ADMIN_EMAILS='.$adminEmail);
+        config(['app.system_admin_emails' => $adminEmail]);
 
         $manager = factory(User::class)->create();
         $admin = factory(User::class)->create(['email' => $adminEmail]);

--- a/tests/Unit/Policies/UserPolicyTest.php
+++ b/tests/Unit/Policies/UserPolicyTest.php
@@ -3,8 +3,9 @@
 namespace Tests\Unit\Policies;
 
 use App\User;
-use Tests\TestCase;
 use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Str;
+use Tests\TestCase;
 
 class UserPolicyTest extends TestCase
 {
@@ -13,10 +14,32 @@ class UserPolicyTest extends TestCase
     /** @test */
     public function manager_can_edit_users_profile()
     {
+        $otherUserManagerId = Str::random();
         $manager = factory(User::class)->create();
         $user = factory(User::class)->create(['manager_id' => $manager->id]);
+        $otherUser = factory(User::class)->create(['manager_id' => $otherUserManagerId]);
 
         $this->assertTrue($manager->can('edit', $user));
+        $this->assertFalse($manager->can('edit', $otherUser));
+    }
+
+    /** @test */
+    public function admins_can_edit_any_user_profile()
+    {
+        $adminEmail = 'admin@example.net';
+        $otherUserManagerId = Str::random();
+        putenv('SYSTEM_ADMIN_EMAILS='.$adminEmail);
+
+        $manager = factory(User::class)->create();
+        $admin = factory(User::class)->create(['email' => $adminEmail]);
+        $user = factory(User::class)->create(['manager_id' => $manager->id]);
+        $otherUser = factory(User::class)->create(['manager_id' => $otherUserManagerId]);
+
+        $this->assertTrue($admin->can('edit', $user));
+        $this->assertTrue($admin->can('edit', $otherUser));
+
+        $this->assertTrue($manager->can('edit', $user));
+        $this->assertFalse($manager->can('edit', $otherUser));
     }
 
     /** @test */

--- a/tests/Unit/Policies/UserPolicyTest.php
+++ b/tests/Unit/Policies/UserPolicyTest.php
@@ -53,10 +53,32 @@ class UserPolicyTest extends TestCase
     /** @test */
     public function manager_can_delete_a_user()
     {
+        $otherUserManagerId = Str::random();
         $manager = factory(User::class)->create();
         $user = factory(User::class)->create(['manager_id' => $manager->id]);
+        $otherUser = factory(User::class)->create(['manager_id' => $otherUserManagerId]);
 
         $this->assertTrue($manager->can('delete', $user));
+        $this->assertFalse($manager->can('delete', $otherUser));
+    }
+
+    /** @test */
+    public function admins_can_delete_any_user()
+    {
+        $adminEmail = 'admin@example.net';
+        $otherUserManagerId = Str::random();
+        putenv('SYSTEM_ADMIN_EMAILS='.$adminEmail);
+
+        $manager = factory(User::class)->create();
+        $admin = factory(User::class)->create(['email' => $adminEmail]);
+        $user = factory(User::class)->create(['manager_id' => $manager->id]);
+        $otherUser = factory(User::class)->create(['manager_id' => $otherUserManagerId]);
+
+        $this->assertTrue($admin->can('delete', $user));
+        $this->assertTrue($admin->can('delete', $otherUser));
+
+        $this->assertTrue($manager->can('delete', $user));
+        $this->assertFalse($manager->can('delete', $otherUser));
     }
 
     /** @test */


### PR DESCRIPTION
In this PR, we are adding possibility for users become System admin, where they can manage all user data on the silsilah system and database backup files.

### How to test

1. Checkout the branch
```
git checkout master
git pull origin
git checkout 49_system_admins
```

2. On `.env` file
```
SYSTEM_ADMIN_EMAILS=admin@email.com;other_admin@email.com
```

3. Use the those email on the existing user, or Insert ones sample admin user (optional):
```
INSERT INTO `users` (`id`, `nickname`, `name`, `gender_id`, `email`, `password`, `created_at`, `updated_at`) VALUES
('e8ea4793-2d56-4fc7-a3eb-9d57013fccc', 'Sysadmin', 'System Admin', '1', 'admin@email.com', '$2y$10$TKh8H1.PfQx37YgCzwiKb.KjNyWgaHb9cbcoQgdIVFlYg7B77UdFm', '2020-04-11 19:21:01', '2020-04-11 19:21:01');
```

4. Login as the admin user:
```
email: admin@email.com
password: secret
```

5. Visit any user's profile, the edit button should be available. Also visit any couple profile, we should see the edit button as well.

This PR should resolves #49.