### PR TITLE
Update Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # use bullseye variant because it doesn't have network issue in m1 mac & intel
-FROM php:7.4-fpm-bullseye
+FROM php:8.1-fpm-bullseye
 
 # Install dependencies
 RUN apt-get update


### PR DESCRIPTION
it is not possible to build with "FROM php:7.4-fpm-bullseye" 

`docker-compose up -d`

```
time="2024-11-11T21:00:12+02:00" level=warning msg="D:\\Utilities\\Code\\PythonArchive\\New\\family-tree-2\\docker-compose.yml: `version` is obsolete"
[+] Running 2/2
 ✔ mysql Pulled                                                                                                                             11.9s 
   ✔ cf09c9b353fa Pull complete                                                                                                              9.3s 
[+] Building 35.5s (16/19)                                                                                                   docker:desktop-linux
 => [app internal] load build definition from Dockerfile                                                                                     0.0s
 => => transferring dockerfile: 762B                                                                                                         0.0s 
 => [app internal] load metadata for docker.io/library/composer:2.2                                                                          1.9s 
 => [app internal] load metadata for docker.io/library/php:7.4-fpm-bullseye                                                                  2.2s 
 => [app internal] load .dockerignore                                                                                                        0.0s
 => => transferring context: 2B                                                                                                              0.0s 
 => [app stage-0  1/13] FROM docker.io/library/php:7.4-fpm-bullseye@sha256:3ac7c8c74b2b047c7cb273469d74fc0d59b857aa44043e6ea6a0084372811d5  11.8s 
 => => resolve docker.io/library/php:7.4-fpm-bullseye@sha256:3ac7c8c74b2b047c7cb273469d74fc0d59b857aa44043e6ea6a0084372811d5b                0.0s 
 => => sha256:3ac7c8c74b2b047c7cb273469d74fc0d59b857aa44043e6ea6a0084372811d5b 1.86kB / 1.86kB                                               0.0s 
 => => sha256:a603fa5e3b4127f210503aaa6189abf6286ee5a73deeaab460f8f33ebc6b64e2 31.41MB / 31.41MB                                             1.8s 
 => => sha256:c428f1a494230852524a2a5957cc5199c36c8b403305e0e877d580bd0ec9e763 226B / 226B                                                   0.5s 
 => => sha256:156740b07ef8a632f9f7bea4e57e4ee5541ade376adf9169351a1265382e39de 91.63MB / 91.63MB                                             7.8s 
 => => sha256:7c6a2cba718f37c4b3ca3486476c7d3dc68dc3ea9b12bde9c57bd4b8d9479fc0 2.41kB / 2.41kB                                               0.0s
 => => sha256:38f2b691dcb8c6d4630caa2999173e35be341f2f1264164ae045d9bfb3906c28 11.38kB / 11.38kB                                             0.0s
 => => sha256:fb5a4c8af82f00730b7427e47bda7f76cea2e2b9aea421750bc9025aface98d8 270B / 270B                                                   0.7s 
 => => sha256:972155ae644b037435eddf206152975f6fd3eaeb1ddeb632709f9c4f9b2bb180 10.74MB / 10.74MB                                             2.0s 
 => => extracting sha256:a603fa5e3b4127f210503aaa6189abf6286ee5a73deeaab460f8f33ebc6b64e2                                                    1.5s 
 => => sha256:a8e3b94fe6c130216f4567f987d8a71cfebc44bb098f9f1d6d18d0e02d6a2c50 491B / 491B                                                   2.0s 
 => => sha256:b922b67ca46b30a57ae7fa2105d7e0bfb954b004a70d0809cf19cfb45df83f48 2.45kB / 2.45kB                                               2.3s 
 => => sha256:93346a3f46bcefa9de4ea57b9043f0b79042a32652169f8306529cde0d9bee96 25.40MB / 25.40MB                                             4.0s 
 => => sha256:6137f893bda625dc11ea72d9c226f43b358e49cd9284c6cb129e3f1369e61d5e 246B / 246B                                                   2.5s 
 => => sha256:79b1a1b78461157a10b5103e206874c1417e79236e89515ad8411dc5b3839a85 8.44kB / 8.44kB                                               2.8s 
 => => extracting sha256:c428f1a494230852524a2a5957cc5199c36c8b403305e0e877d580bd0ec9e763                                                    0.0s 
 => => extracting sha256:156740b07ef8a632f9f7bea4e57e4ee5541ade376adf9169351a1265382e39de                                                    2.8s 
 => => extracting sha256:fb5a4c8af82f00730b7427e47bda7f76cea2e2b9aea421750bc9025aface98d8                                                    0.0s 
 => => extracting sha256:972155ae644b037435eddf206152975f6fd3eaeb1ddeb632709f9c4f9b2bb180                                                    0.1s 
 => => extracting sha256:a8e3b94fe6c130216f4567f987d8a71cfebc44bb098f9f1d6d18d0e02d6a2c50                                                    0.0s 
 => => extracting sha256:93346a3f46bcefa9de4ea57b9043f0b79042a32652169f8306529cde0d9bee96                                                    0.5s 
 => => extracting sha256:b922b67ca46b30a57ae7fa2105d7e0bfb954b004a70d0809cf19cfb45df83f48                                                    0.0s 
 => => extracting sha256:6137f893bda625dc11ea72d9c226f43b358e49cd9284c6cb129e3f1369e61d5e                                                    0.0s 
 => => extracting sha256:79b1a1b78461157a10b5103e206874c1417e79236e89515ad8411dc5b3839a85                                                    0.0s 
 => [app internal] load build context                                                                                                        0.1s 
 => => transferring context: 4.11MB                                                                                                          0.1s 
 => [app] FROM docker.io/library/composer:2.2@sha256:c6fac168ae2b649c9365a64bd74750fc61e611925c2ee23a612280a2de9ae37a                        9.8s 
 => => resolve docker.io/library/composer:2.2@sha256:c6fac168ae2b649c9365a64bd74750fc61e611925c2ee23a612280a2de9ae37a                        0.0s 
 => => sha256:2f29139cc4bbebb71fe86a599b5478af1b2d1b518055271322709ae024aee85e 3.60kB / 3.60kB                                               0.0s 
 => => sha256:188bc27148f324522fb88717bf1dbcffeb2676c98bf15026bffbc46560d4299a 11.77kB / 11.77kB                                             0.0s 
 => => sha256:c6fac168ae2b649c9365a64bd74750fc61e611925c2ee23a612280a2de9ae37a 10.08kB / 10.08kB                                             0.0s 
 => => sha256:43c4264eed91be63b206e17d93e75256a6097070ce643c5e8f0379998b44f170 3.62MB / 3.62MB                                               3.6s 
 => => extracting sha256:43c4264eed91be63b206e17d93e75256a6097070ce643c5e8f0379998b44f170                                                    0.1s 
 => => sha256:bf435f7f9424ea9fcf601de93a4a2db77f486c259f3b7bc231e1961601a4f37d 5.58MB / 5.58MB                                               4.3s 
 => => sha256:449bd539bba62701845e2fa08f857713e36f72251fd92d3fede3fb3e809a27b4 944B / 944B                                                   4.3s 
 => => sha256:146903a2d9bcb11123399ab1526ba7a0c973f31a11dc8f22a15a13ef704bfc70 216B / 216B                                                   4.4s 
 => => extracting sha256:bf435f7f9424ea9fcf601de93a4a2db77f486c259f3b7bc231e1961601a4f37d                                                    0.1s 
 => => sha256:20e360f8f351026cced5d4d2d0d2747d12d9eea9f77b393e15c229e223f3bee8 12.50MB / 12.50MB                                             5.7s 
 => => extracting sha256:449bd539bba62701845e2fa08f857713e36f72251fd92d3fede3fb3e809a27b4                                                    0.0s 
 => => sha256:b19f7ef2201d62827b3a86888aeebc3d519feb16136650307dd5b8552e9aa080 486B / 486B                                                   4.7s
 => => extracting sha256:146903a2d9bcb11123399ab1526ba7a0c973f31a11dc8f22a15a13ef704bfc70                                                    0.0s 
 => => sha256:edae59e3b482212c12e156fe6f8ac0d17a8cbfc5c310189e1b2a48e982076029 17.22MB / 17.22MB                                             6.6s 
 => => extracting sha256:20e360f8f351026cced5d4d2d0d2747d12d9eea9f77b393e15c229e223f3bee8                                                    0.1s 
 => => sha256:c10e488cd237e804f165c8dc9a2a62ea8b370faaf60242bb9bd0c1a8fd601d07 2.44kB / 2.44kB                                               5.9s 
 => => extracting sha256:b19f7ef2201d62827b3a86888aeebc3d519feb16136650307dd5b8552e9aa080                                                    0.0s 
 => => sha256:9104032f5dd035d50b8b9bf589fb608be59cb18fb6a30d69959d561b817f7b24 19.66kB / 19.66kB                                             6.1s 
 => => sha256:2f7d801bb5238c5aa68a6b4605a6c0b0a93de2068eeed83a143a73e992db189d 30.37MB / 30.37MB                                             8.2s 
 => => extracting sha256:edae59e3b482212c12e156fe6f8ac0d17a8cbfc5c310189e1b2a48e982076029                                                    0.7s 
 => => sha256:c77d700ee32f0d34d336b9b15cc1d6d1367a881561ff9bce15ee3d3ef30fed40 256B / 256B                                                   6.8s 
 => => sha256:108159cbcf8864755a3a568aa0da038eca3d045aba5320c9c6db87ebfc853aea 935.91kB / 935.91kB                                           7.2s 
 => => sha256:bb810ead8cc18947624273f591963375c92d3e8111b1e3344c450a5c50605529 419B / 419B                                                   7.4s 
 => => extracting sha256:c10e488cd237e804f165c8dc9a2a62ea8b370faaf60242bb9bd0c1a8fd601d07                                                    0.0s 
 => => extracting sha256:9104032f5dd035d50b8b9bf589fb608be59cb18fb6a30d69959d561b817f7b24                                                    0.0s 
 => => sha256:9686a2049ee3defdc7d2f597170c502c287745e09d084888f3492cf22bc24183 91B / 91B                                                     7.7s 
 => => extracting sha256:2f7d801bb5238c5aa68a6b4605a6c0b0a93de2068eeed83a143a73e992db189d                                                    1.1s 
 => => extracting sha256:c77d700ee32f0d34d336b9b15cc1d6d1367a881561ff9bce15ee3d3ef30fed40                                                    0.0s 
 => => extracting sha256:108159cbcf8864755a3a568aa0da038eca3d045aba5320c9c6db87ebfc853aea                                                    0.0s 
 => => extracting sha256:bb810ead8cc18947624273f591963375c92d3e8111b1e3344c450a5c50605529                                                    0.0s 
 => => extracting sha256:9686a2049ee3defdc7d2f597170c502c287745e09d084888f3492cf22bc24183                                                    0.0s 
 => [app stage-0  2/13] RUN apt-get update                                                                                                   2.5s 
 => [app stage-0  3/13] RUN apt-get install -y zip nginx git                                                                                 9.2s 
 => [app stage-0  4/13] RUN useradd -r nginx                                                                                                 0.5s 
 => [app stage-0  5/13] RUN docker-php-ext-install pdo pdo_mysql     && docker-php-ext-enable pdo_mysql                                      7.9s 
 => [app stage-0  6/13] WORKDIR /var/www                                                                                                     0.0s 
 => [app stage-0  7/13] COPY . .                                                                                                             0.1s 
 => [app stage-0  8/13] RUN mv nginx.conf /etc/nginx/nginx.conf                                                                              0.4s 
 => [app stage-0  9/13] COPY --from=composer:2.2 /usr/bin/composer /usr/bin/composer                                                         0.1s 
 => ERROR [app stage-0 10/13] RUN composer install                                                                                           0.6s 
------
 > [app stage-0 10/13] RUN composer install:
0.544 Do not run Composer as root/super user! See https://getcomposer.org/root for details
0.578 Installing dependencies from lock file (including require-dev)
0.585 Verifying lock file contents can be installed on current platform.
0.596 Your lock file does not contain a compatible set of packages. Please run composer update.
0.596
0.596   Problem 1
0.596     - Root composer.json requires php ^8.1 but your php version (7.4.33) does not satisfy that requirement.
0.596   Problem 2
0.596     - intervention/gif is locked to version 4.2.0 and an update of this package was not requested.
0.596     - intervention/gif 4.2.0 requires php ^8.1 -> your php version (7.4.33) does not satisfy that requirement.
0.596   Problem 3
0.596     - intervention/image is locked to version 3.8.0 and an update of this package was not requested.
0.596     - intervention/image 3.8.0 requires php ^8.1 -> your php version (7.4.33) does not satisfy that requirement.
0.596   Problem 4
0.596     - intervention/image-laravel is locked to version 1.3.0 and an update of this package was not requested.
0.596     - intervention/image-laravel 1.3.0 requires php ^8.1 -> your php version (7.4.33) does not satisfy that requirement.
0.596
------
failed to solve: process "/bin/sh -c composer install" did not complete successfully: exit code: 2
```
![image](https://github.com/user-attachments/assets/cc2aad16-6f64-4eca-bc87-8b8af975e76e)
